### PR TITLE
Use versioning needed for GitHub src

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Sharing (CORS) preflight requests.
 
 ``` hcl
 module "cors" {
-  source = "github.com/squidfunk/terraform-aws-api-gateway-enable-cors"
-  version = "0.3.0"
+  source = "github.com/squidfunk/terraform-aws-api-gateway-enable-cors?ref=0.3.0"
 
   api_id          = "<api_id>"
   api_resource_id = "<api_resource_id>"


### PR DESCRIPTION
`version` doesn't work for non-repo based modules.  So move the version into the src URL.