### PR TITLE
Output resources for external access

### DIFF
--- a/headers.tf
+++ b/headers.tf
@@ -24,45 +24,39 @@
 
 # local.*
 locals {
-  headers = "${
-    map(
+  headers = map(
       "Access-Control-Allow-Headers"    , "'${join(",", var.allow_headers)}'",
       "Access-Control-Allow-Methods"    , "'${join(",", var.allow_methods)}'",
       "Access-Control-Allow-Origin"     , "'${var.allow_origin}'",
       "Access-Control-Max-Age"          , "'${var.allow_max_age}'",
-      "Access-Control-Allow-Credentials", "${var.allow_credentials ? "'true'" : ""}"
-    )
-  }"
+      "Access-Control-Allow-Credentials", var.allow_credentials ? "'true'" : ""
+  )
 
   # Pick non-empty header values
-  header_values = "${compact(values(local.headers))}"
+  header_values = compact(values(local.headers))
 
   # Pick names that from non-empty header values
-  header_names = "${matchkeys(
+  header_names = matchkeys(
     keys(local.headers),
     values(local.headers),
     local.header_values
-  )}"
+  )
 
   # Parameter names for method and integration responses
-  parameter_names = "${
-    formatlist("method.response.header.%s", local.header_names)
-  }"
+  parameter_names = formatlist("method.response.header.%s", local.header_names)
 
   # Map parameter list to "true" values
-  true_list = "${
-    split("|", replace(join("|", local.parameter_names), "/[^|]+/", "true"))
-  }"
+  true_list = split("|", replace(join("|", local.parameter_names), "/[^|]+/", "true"))
 
   # Integration response parameters
-  integration_response_parameters = "${zipmap(
+  integration_response_parameters = zipmap(
     local.parameter_names,
     local.header_values
-  )}"
+  )
 
   # Method response parameters
-  method_response_parameters = "${zipmap(
+  method_response_parameters = zipmap(
     local.parameter_names,
     local.true_list
-  )}"
+  )
 }

--- a/main.tf
+++ b/main.tf
@@ -24,17 +24,17 @@
 
 # aws_api_gateway_method._
 resource "aws_api_gateway_method" "_" {
-  rest_api_id   = "${var.api_id}"
-  resource_id   = "${var.api_resource_id}"
+  rest_api_id   = var.api_id
+  resource_id   = var.api_resource_id
   http_method   = "OPTIONS"
   authorization = "NONE"
 }
 
 # aws_api_gateway_integration._
 resource "aws_api_gateway_integration" "_" {
-  rest_api_id = "${var.api_id}"
-  resource_id = "${var.api_resource_id}"
-  http_method = "${aws_api_gateway_method._.http_method}"
+  rest_api_id = var.api_id
+  resource_id = var.api_resource_id
+  http_method = aws_api_gateway_method._.http_method
 
   type = "MOCK"
 
@@ -45,12 +45,12 @@ resource "aws_api_gateway_integration" "_" {
 
 # aws_api_gateway_integration_response._
 resource "aws_api_gateway_integration_response" "_" {
-  rest_api_id = "${var.api_id}"
-  resource_id = "${var.api_resource_id}"
-  http_method = "${aws_api_gateway_method._.http_method}"
+  rest_api_id = var.api_id
+  resource_id = var.api_resource_id
+  http_method = aws_api_gateway_method._.http_method
   status_code = 200
 
-  response_parameters = "${local.integration_response_parameters}"
+  response_parameters = local.integration_response_parameters
 
   depends_on = [
     aws_api_gateway_integration._,
@@ -60,12 +60,12 @@ resource "aws_api_gateway_integration_response" "_" {
 
 # aws_api_gateway_method_response._
 resource "aws_api_gateway_method_response" "_" {
-  rest_api_id = "${var.api_id}"
-  resource_id = "${var.api_resource_id}"
-  http_method = "${aws_api_gateway_method._.http_method}"
+  rest_api_id = var.api_id
+  resource_id = var.api_resource_id
+  http_method = aws_api_gateway_method._.http_method
   status_code = 200
 
-  response_parameters = "${local.method_response_parameters}"
+  response_parameters = local.method_response_parameters
 
   response_models = {
     "application/json" = "Empty"

--- a/main.tf
+++ b/main.tf
@@ -53,8 +53,8 @@ resource "aws_api_gateway_integration_response" "_" {
   response_parameters = "${local.integration_response_parameters}"
 
   depends_on = [
-    "aws_api_gateway_integration._",
-    "aws_api_gateway_method_response._",
+    aws_api_gateway_integration._,
+    aws_api_gateway_method_response._,
   ]
 }
 
@@ -72,6 +72,6 @@ resource "aws_api_gateway_method_response" "_" {
   }
 
   depends_on = [
-    "aws_api_gateway_method._",
+    aws_api_gateway_method._,
   ]
 }

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,15 @@
+output "aws_api_gateway_method" {
+  value = aws_api_gateway_method._
+}
+
+output "aws_api_gateway_integration" {
+  value = aws_api_gateway_integration._
+}
+
+output "aws_api_gateway_integration_response" {
+  value = aws_api_gateway_integration_response._
+}
+
+output "aws_api_gateway_method_response" {
+  value = aws_api_gateway_method_response._
+}

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "api_resource_id" {
 # var.allow_headers
 variable "allow_headers" {
   description = "Allow headers"
-  type        = "list"
+  type        = list(string)
 
   default = [
     "Authorization",
@@ -53,7 +53,7 @@ variable "allow_headers" {
 # var.allow_methods
 variable "allow_methods" {
   description = "Allow methods"
-  type        = "list"
+  type        = list(string)
 
   default = [
     "OPTIONS",
@@ -69,14 +69,14 @@ variable "allow_methods" {
 # var.allow_origin
 variable "allow_origin" {
   description = "Allow origin"
-  type        = "string"
+  type        = string
   default     = "*"
 }
 
 # var.allow_max_age
 variable "allow_max_age" {
   description = "Allow response caching time"
-  type        = "string"
+  type        = string
   default     = "7200"
 }
 


### PR DESCRIPTION
Output the resource values so that they can be used externally.  I'm using these to trigger an API redeployment, no other way to trigger this without these which will convey that a change has happened.

This is built on top of the Terraform 0.12 cleanups in #6 