### PR TITLE
fix: 500 errors on OPTIONS requests when using */* in Binary Media Types

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,7 @@ resource "aws_api_gateway_integration" "_" {
   rest_api_id = var.api_id
   resource_id = var.api_resource_id
   http_method = aws_api_gateway_method._.http_method
+  content_handling = "CONVERT_TO_TEXT"
 
   type = "MOCK"
 


### PR DESCRIPTION
When enabling Binary Media Types in API Gateway, the most flexible setting is to use */* as it does not require a client to send an Accept: header. However, this then starts causing OPTIONS methods to begin failing with 500 errors due API Gateway not knowing how to encode the response.

AWS recommends to set the content handling to "CONVERT_TO_TEXT", see:
https://forums.aws.amazon.com/thread.jspa?threadID=256140