### PR TITLE
Changed deprecated map function to modern tomap

### DIFF
--- a/headers.tf
+++ b/headers.tf
@@ -24,13 +24,13 @@
 
 # local.*
 locals {
-  headers = map(
+  headers = tomap({
     "Access-Control-Allow-Headers", "'${join(",", var.allow_headers)}'",
     "Access-Control-Allow-Methods", "'${join(",", var.allow_methods)}'",
     "Access-Control-Allow-Origin", "'${var.allow_origin}'",
     "Access-Control-Max-Age", "'${var.allow_max_age}'",
     "Access-Control-Allow-Credentials", var.allow_credentials ? "'true'" : ""
-  )
+  })
 
   # Pick non-empty header values
   header_values = compact(values(local.headers))


### PR DESCRIPTION
`map` function was deprecated in Terraform v0.12 and recommended replacement is with `tomap({ ... })`.
Solves #12 issue