### PR TITLE
Fix syntax for TF 0.15

### DIFF
--- a/headers.tf
+++ b/headers.tf
@@ -25,11 +25,11 @@
 # local.*
 locals {
   headers = tomap({
-    "Access-Control-Allow-Headers", "'${join(",", var.allow_headers)}'",
-    "Access-Control-Allow-Methods", "'${join(",", var.allow_methods)}'",
-    "Access-Control-Allow-Origin", "'${var.allow_origin}'",
-    "Access-Control-Max-Age", "'${var.allow_max_age}'",
-    "Access-Control-Allow-Credentials", var.allow_credentials ? "'true'" : ""
+    "Access-Control-Allow-Headers"     = "'${join(",", var.allow_headers)}'"
+    "Access-Control-Allow-Methods"     = "'${join(",", var.allow_methods)}'"
+    "Access-Control-Allow-Origin"      = "'${var.allow_origin}'"
+    "Access-Control-Max-Age"           = "'${var.allow_max_age}'"
+    "Access-Control-Allow-Credentials" = var.allow_credentials ? "'true'" : ""
   })
 
   # Pick non-empty header values

--- a/headers.tf
+++ b/headers.tf
@@ -24,13 +24,13 @@
 
 # local.*
 locals {
-  headers = tomap({
+  headers = {
     "Access-Control-Allow-Headers"     = "'${join(",", var.allow_headers)}'"
     "Access-Control-Allow-Methods"     = "'${join(",", var.allow_methods)}'"
     "Access-Control-Allow-Origin"      = "'${var.allow_origin}'"
     "Access-Control-Max-Age"           = "'${var.allow_max_age}'"
     "Access-Control-Allow-Credentials" = var.allow_credentials ? "'true'" : ""
-  })
+  }
 
   # Pick non-empty header values
   header_values = compact(values(local.headers))


### PR DESCRIPTION
This PR fixes syntax to be compatible with Terraform 0.15.0 release. 

Change merged in https://github.com/squidfunk/terraform-aws-api-gateway-enable-cors/pull/13 doesn't fix the issue - `tomap` requires different syntax. Actually it removes `tomap` completely as it is not needed at all.

(Finally) closes #12 


