### PR TITLE
fix: use tomap to build headers tf >= 0.12

### DIFF
--- a/headers.tf
+++ b/headers.tf
@@ -24,13 +24,13 @@
 
 # local.*
 locals {
-  headers = {
-    "Access-Control-Allow-Headers"     = "'${join(",", var.allow_headers)}'"
-    "Access-Control-Allow-Methods"     = "'${join(",", var.allow_methods)}'"
-    "Access-Control-Allow-Origin"      = "'${var.allow_origin}'"
-    "Access-Control-Max-Age"           = "'${var.allow_max_age}'"
+  headers = tomap({
+    "Access-Control-Allow-Headers" = "'${join(",", var.allow_headers)}'",
+    "Access-Control-Allow-Methods" = "'${join(",", var.allow_methods)}'",
+    "Access-Control-Allow-Origin" = "'${var.allow_origin}'",
+    "Access-Control-Max-Age" = "'${var.allow_max_age}'",
     "Access-Control-Allow-Credentials" = var.allow_credentials ? "'true'" : ""
-  }
+  })
 
   # Pick non-empty header values
   header_values = compact(values(local.headers))


### PR DESCRIPTION
#16 

Tested on Terraform 1.1.3, this will break terraform < v0.12